### PR TITLE
from isHexNumber to isHexColor

### DIFF
--- a/justgage.js
+++ b/justgage.js
@@ -1031,8 +1031,8 @@
   function updateProp(obj, option, val) {
     switch (option) {
       case 'valueFontColor':
-        if (!isHexNumber(val)) {
-          console.log('* justgage: the updated valueFontColor value is not a valid hex value');
+        if (!isHexColor(val)) {
+          console.log('* justgage: the updated valueFontColor value is not a valid hex color');
           break;
         }
 
@@ -1042,8 +1042,8 @@
         break;
 
       case 'labelFontColor':
-        if (!isHexNumber(val)) {
-          console.log('* justgage: the updated labelFontColor value is not a valid hex value');
+        if (!isHexColor(val)) {
+          console.log('* justgage: the updated labelFontColor value is not a valid hex color');
           break;
         }
 
@@ -1268,13 +1268,13 @@
   }
 
   /**
-   * Validate if hex value
+   * Validate if html hex color presentation
    *
    * @param val
    * @returns {*|boolean}
    */
-  function isHexNumber(val) {
-    var regExp = /^[-+]?[0-9A-Fa-f]+\.?[0-9A-Fa-f]*?$/;
+  function isHexColor(val) {
+    var regExp = /^#([0-9A-Fa-f]{3}){1,2}$/;
     return (typeof val === 'string' && regExp.test(val));
   }
 


### PR DESCRIPTION
Thanks for the fix of #342 - now loads OK. However, giving a plain hex number is not good for a color string: Please allow to give a string in #aabbcc or #fff or #AABBCC or #FFF format  as parameter and the font color actually changes to something else than to black only as it does in 1.3.4. Tested on Windows and Linux using various browsers (including wxWidgets WebView).